### PR TITLE
Bugfix: incorrectly wrapping text description of substeps

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.10.15: Bugfix: incorrectly wrapping text description of substeps
+   * When printing the description of the substeps in the loop, the code incorrectly
+     wrapped the text, which caused issues with e.g. tables.
+     
 2024.8.23 -- Enhancement to 'For' loops
    * For integer loops, ensure that the loop variable is an integer and
      make the directory name be value of the loop variable to make it easier

--- a/loop_step/loop.py
+++ b/loop_step/loop.py
@@ -136,7 +136,7 @@ class Loop(seamm.Node):
         next_node = self.loop_node()
         while next_node is not None and next_node != join_node:
             text += "\n\n"
-            text += __(next_node.description_text(), indent=4 * " ").__str__()
+            text += str(__(next_node.description_text(), indent=4 * " ", wrap=False))
             next_node = next_node.next()
 
         return text


### PR DESCRIPTION
* When printing the description of the substeps in the loop, the code incorrectly wrapped the text, which caused issues with e.g. tables.