### PR TITLE
Bugfix: Directory name widget not displayed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.12.23: Bugfix: Directory name widget not displayed
+   * The directory name widget was not displayed for loops over systems in the database.
+     This is now corrected.
+
 2024.11.19: Bugfix: error in selection of table rows
    * In a loop "For rows in table" a crietrion on the value of a row might cause an
      error due to mismatch of the types. This is now corrected.

--- a/loop_step/tk_loop.py
+++ b/loop_step/tk_loop.py
@@ -238,6 +238,7 @@ class TkLoop(seamm.TkNode):
             row += 1
             frame.columnconfigure(3, weight=1)
             self["directory name"].grid(row=row, column=0, columnspan=3, sticky=tk.W)
+            row += 1
         else:
             raise RuntimeError("Don't recognize the loop_type {}".format(loop_type))
         self["errors"].grid(row=row, column=0, columnspan=4, sticky=tk.W)


### PR DESCRIPTION
* The directory name widget was not displayed for loops over systems in the database. This is now corrected.